### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,102 @@
+@Library('xmos_jenkins_shared_library@v0.30.0') _
+
+getApproval()
+
+pipeline {
+  agent {
+    label 'x86_64 && linux'
+  }
+  options {
+    buildDiscarder(xmosDiscardBuildSettings())
+    skipDefaultCheckout()
+  }
+  parameters {
+    string(
+      name: 'TOOLS_VERSION',
+      defaultValue: '15.2.1',
+      description: 'The XTC tools version'
+    )
+  }
+  environment {
+    PIP_VERSION = "24.0"
+    PYTHON_VERSION = "3.12.1"
+  }
+  stages {
+    stage('Get sandbox') {
+      steps {
+        println "Stage running on: ${env.NODE_NAME}"
+
+        sh "git clone -b v1.2.1 git@github.com:xmos/infr_scripts_py"
+        sh "git clone -b v1.5.0 git@github.com:xmos/infr_apps"
+
+        dir("lib_adat") {
+          checkout scm
+
+          createVenv()
+          withVenv {
+            sh "pip install -e ${WORKSPACE}/infr_scripts_py"
+            sh "pip install -e ${WORKSPACE}/infr_apps"
+          }
+        }
+      }
+    }  // Get sandbox
+    stage('Library checks') {
+      steps {
+        withTools(params.TOOLS_VERSION) {
+          // creation of tools_released and REPO environment variable are workarounds
+          // to allow xcoreLibraryChecks to run without a viewfile-based sandbox
+          dir("tools_released") {
+            sh "echo ${params.TOOLS_VERSION} > REQUIRED_TOOLS_VERSION"
+          }
+          withEnv(["REPO=lib_adat"]) {
+            xcoreLibraryChecks("lib_adat", false)
+          }
+        }
+      }
+    }  // Library checks
+    stage('Build examples') {
+      steps {
+        withTools(params.TOOLS_VERSION) {
+          dir("lib_adat/examples") {
+            script {
+              // Build all apps in the examples directory
+              def apps = sh(script: "ls -d app_*", returnStdout: true).trim()
+              for(String app : apps.split()) {
+                sh "xmake -C ${app}"
+              }
+            }
+          }
+        }
+      }
+    }  // Build examples
+    stage('Build documentation') {
+      steps {
+        // Clone infrastructure repositories and setup viewEnv environment as a
+        // workaround until this is converted to use xmosdoc
+        sh "git clone -b swapps14 git@github.com:xmos/infr_scripts_pl"
+        sh "git clone -b feature/update_xdoc_3_3_0 git@github0.xmos.com:xmos-int/xdoc_released"
+        withAgentEnv() {
+          sh """#!/bin/bash
+                cd ${WORKSPACE}/infr_scripts_pl/Build
+                source SetupEnv
+                cd ${WORKSPACE}
+                Build.pl VIEW=apps DOMAINS=xdoc_released
+                """
+        }
+        viewEnv {
+          withTools(params.TOOLS_VERSION) {
+            dir("lib_adat/lib_adat/doc") {
+              sh "xdoc xmospdf"
+              archiveArtifacts artifacts: "pdf/*.pdf", fingerprint: true, allowEmptyArchive: false
+            }
+          }
+        }
+      }
+    }  // Build documentation
+  }
+  post {
+    cleanup {
+      xcoreCleanSandbox()
+    }
+  }
+}


### PR DESCRIPTION
Added a Jenkinsfile without using an xgit viewfile. There were two parts that needed workaround: running the library checks, and building the documentation. Both of these can be cleaned up in the future. The generated PDF is stored as an artifact and looks the same as the last one that was released.